### PR TITLE
feat(cli): allow to login from CLI and use that authenticator instance for the webservice

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,11 +39,6 @@ pub struct CmdArgs {
 pub fn run() -> Result<(), String> {
     let args = CmdArgs::from_args();
 
-    if let Some(host_port) = args.daemon {
-        authd::run(host_port);
-        return Ok(());
-    }
-
     let mut authenticator: Option<Authenticator> = None;
 
     if let (Some(secret), Some(password), Some(invite)) =
@@ -135,6 +130,10 @@ pub fn run() -> Result<(), String> {
             }
         }
     };
+
+    if let Some(host_port) = args.daemon {
+        authd::run(host_port, authenticator);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Allow to log in with CLI (either by creating an acc or just logging in) and if `-d` is provided it uses the created authenticator instance for the webservice itself, thus you can then send any HTTP requests with no need to login (I also made all functions except for `run` private in the `authd` mod as agreed)  