### PR TITLE
fix(revoke): properly handle the error when the app id is not valid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,18 +2082,19 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.37.0 (git+https://github.com/hunterlester/routing?branch=0.37.0-upgrades)",
  "rpassword 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe_authenticator 0.9.1 (git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-0.9.1-upgrades)",
- "safe_core 0.32.1 (git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-0.9.1-upgrades)",
+ "safe_authenticator 0.9.1 (git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-master-upgrades)",
+ "safe_core 0.32.1 (git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-master-upgrades)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "safe_authenticator"
 version = "0.9.1"
-source = "git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-0.9.1-upgrades#cb91e147d09f3ae7c84dd9788d03aa85510b3389"
+source = "git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-master-upgrades#d968ddabc05fad9d54a6ea011fd3f39fd12e1b6b"
 dependencies = [
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2106,7 +2107,7 @@ dependencies = [
  "routing 0.37.0 (git+https://github.com/hunterlester/routing?branch=0.37.0-upgrades)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_bindgen 0.11.0 (git+https://github.com/hunterlester/safe_bindgen?branch=0.11.0-upgrades)",
- "safe_core 0.32.1 (git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-0.9.1-upgrades)",
+ "safe_core 0.32.1 (git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-master-upgrades)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2134,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "safe_core"
 version = "0.32.1"
-source = "git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-0.9.1-upgrades#cb91e147d09f3ae7c84dd9788d03aa85510b3389"
+source = "git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-master-upgrades#d968ddabc05fad9d54a6ea011fd3f39fd12e1b6b"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3393,9 +3394,9 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
-"checksum safe_authenticator 0.9.1 (git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-0.9.1-upgrades)" = "<none>"
+"checksum safe_authenticator 0.9.1 (git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-master-upgrades)" = "<none>"
 "checksum safe_bindgen 0.11.0 (git+https://github.com/hunterlester/safe_bindgen?branch=0.11.0-upgrades)" = "<none>"
-"checksum safe_core 0.32.1 (git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-0.9.1-upgrades)" = "<none>"
+"checksum safe_core 0.32.1 (git+https://github.com/bochaco/safe_client_libs?branch=safe_authenticator-master-upgrades)" = "<none>"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,8 @@ log = "0.4.6"
 rpassword = "3.0.1"
 structopt = "0.2.14"
 env_logger = "0.6.0"
-#safe_authenticator = { git = "https://github.com/hunterlester/safe_client_libs", branch = "safe_authenticator-0.9.0-upgrades" }
-#safe_authenticator = { git = "https://github.com/joshuef/safe_client_libs", branch = "safe_authenticator-0.9.0-upgrades" }
-safe_authenticator = { git = "https://github.com/bochaco/safe_client_libs", branch = "safe_authenticator-0.9.1-upgrades" }
-safe_core = { git = "https://github.com/bochaco/safe_client_libs", branch = "safe_authenticator-0.9.1-upgrades" }
+safe_authenticator = { git = "https://github.com/bochaco/safe_client_libs", branch = "safe_authenticator-master-upgrades" }
+safe_core = { git = "https://github.com/bochaco/safe_client_libs", branch = "safe_authenticator-master-upgrades" }
 routing = { git = "https://github.com/hunterlester/routing", branch = "0.37.0-upgrades" }
 maidsafe_utilities = { git = "https://github.com/hunterlester/maidsafe_utilities", branch = "0.17.0-upgrades" }
 futures = "0.1.25"
@@ -27,6 +25,7 @@ serde = "1.0.89"
 serde_json = "1.0.39"
 envy = "0.4.0"
 serde_derive = "1.0.89"
+unwrap = "~1.2.0"
 
 [features]
 testing = ["safe_authenticator/testing"]

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -98,8 +98,8 @@ pub fn get_login_details(config_file: &Option<String>) -> Result<LoginDetails, S
 
 pub fn pretty_print_authed_apps(authed_apps: Vec<AuthedAppsList>) {
     let mut table = Table::new();
-    table.add_row(row!["Authorised Applications"]);
-    table.add_row(row!["Id", "Name", "Vendor", "Permissions"]);
+    table.add_row(row![bFg->"Authorised Applications"]);
+    table.add_row(row![bFg->"Id", bFg->"Name", bFg->"Vendor", bFg->"Permissions"]);
 
     let all_app_iterator = authed_apps.iter();
     for app_info in all_app_iterator {
@@ -149,7 +149,7 @@ pub fn prompt_to_allow_auth(req: IpcReq) -> bool {
         IpcReq::Auth(app_auth_req) => {
             println!("The following application authorisation request was received:");
             let mut table = Table::new();
-            table.add_row(row!["Id", "Name", "Vendor", "Permissions requested"]);
+            table.add_row(row![bFg->"Id", bFg->"Name", bFg->"Vendor", bFg->"Permissions requested"]);
             table.add_row(row![
                 app_auth_req.app.id,
                 app_auth_req.app.name,
@@ -166,7 +166,7 @@ pub fn prompt_to_allow_auth(req: IpcReq) -> bool {
             println!("The following authorisation request for containers was received:");
             println!("{:?}", cont_req);
             let mut table = Table::new();
-            table.add_row(row!["Id", "Name", "Vendor", "Permissions requested"]);
+            table.add_row(row![bFg->"Id", bFg->"Name", bFg->"Vendor", bFg->"Permissions requested"]);
             table.add_row(row![
                 cont_req.app.id,
                 cont_req.app.name,
@@ -216,10 +216,10 @@ pub fn prompt_to_allow_auth(req: IpcReq) -> bool {
             }
             let mut table = Table::new();
             table.add_row(row![
-                "Id",
-                "Name",
-                "Vendor",
-                "MutableData's requested to share"
+                bFg->"Id",
+                bFg->"Name",
+                bFg->"Vendor",
+                bFg->"MutableData's requested to share"
             ]);
             table.add_row(row![
                 share_mdata_req.app.id,

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -6,20 +6,18 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use log::info;
-use prettytable::Table;
-
-use routing::Action;
-use safe_auth::AuthedAppsList;
-use safe_core::ipc::req::IpcReq;
+extern crate envy;
 extern crate serde;
 extern crate serde_json;
 
+use log::info;
+use prettytable::Table;
+use routing::Action;
+use safe_auth::AuthedAppsList;
+use safe_core::ipc::req::IpcReq;
+use serde::Deserialize;
 use std::fs;
 use std::io::{stdin, stdout, Write};
-
-use serde::Deserialize;
-extern crate envy;
 
 #[derive(Deserialize, Debug)]
 struct Environment {
@@ -37,7 +35,7 @@ pub fn get_login_details(config_file: &Option<String>) -> Result<LoginDetails, S
     let mut the_secret: String = String::from("");
     let mut the_password: String = String::from("");
 
-    let environment_details = envy::from_env::<Environment>().unwrap();
+    let environment_details = unwrap!(envy::from_env::<Environment>());
 
     if let Some(safe_auth_secret) = environment_details.safe_auth_secret {
         the_secret = safe_auth_secret;
@@ -62,7 +60,7 @@ pub fn get_login_details(config_file: &Option<String>) -> Result<LoginDetails, S
                 }
             };
 
-            let json: serde_json::Value = serde_json::from_reader(file).unwrap();
+            let json: serde_json::Value = unwrap!(serde_json::from_reader(file));
 
             eprintln!("Warning! Storing your secret/password in plaintext in a config file is not secure." );
 
@@ -79,8 +77,8 @@ pub fn get_login_details(config_file: &Option<String>) -> Result<LoginDetails, S
             }
         } else {
             // Prompt the user for the SAFE account credentials
-            the_secret = rpassword::read_password_from_tty(Some("Secret: ")).unwrap();
-            the_password = rpassword::read_password_from_tty(Some("Password: ")).unwrap();
+            the_secret = unwrap!(rpassword::read_password_from_tty(Some("Secret: ")));
+            the_password = unwrap!(rpassword::read_password_from_tty(Some("Password: ")));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,17 +6,18 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-mod authd;
-mod cli_helpers;
-
-use env_logger;
-use log::{debug, error};
 #[macro_use]
 extern crate prettytable;
+#[macro_use]
+extern crate unwrap;
 
+mod authd;
 mod cli;
+mod cli_helpers;
 
 use cli::run;
+use env_logger;
+use log::{debug, error};
 use std::process;
 
 fn main() {


### PR DESCRIPTION
Use `unwrap!` macro instead of `.unwrap()`
Accomodate and re-enable a couple of ignored tests
When listing information on the console set the table headers to be green and bold

![image](https://user-images.githubusercontent.com/442821/56435825-35ecfa80-62b0-11e9-8163-ff9f2a902d90.png)
![image](https://user-images.githubusercontent.com/442821/56435870-5e74f480-62b0-11e9-8e3c-c052bb91a63d.png)
