### PR TITLE
Nightly Build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,13 +60,13 @@ stage("deploy") {
         }
     }
     if (env.BRANCH_NAME == "master") {
-        build(job: '../rust_cache_build-safe_auth_cli-windows', wait: false)
-        build(job: '../docker_build-safe_auth_cli_build_container', wait: false)
+        build(job: "../rust_cache_build-safe_auth_cli-windows", wait: false)
+        build(job: "../docker_build-safe_auth_cli_build_container", wait: false)
     }
 }
 
 def retrieveCache() {
-    if (!fileExists('target')) {
+    if (!fileExists("target")) {
         withEnv(["SAFE_AUTH_BRANCH=${params.CACHE_BRANCH}"]) {
             sh("make retrieve-cache")
         }
@@ -83,14 +83,14 @@ def packageBuildArtifacts(os) {
 }
 
 def uploadBuildArtifacts() {
-    withAWS(credentials: 'aws_jenkins_build_artifacts_user', region: 'eu-west-2') {
-        def artifacts = sh(returnStdout: true, script: 'ls -1 artifacts').trim().split("\\r?\\n")
+    withAWS(credentials: "aws_jenkins_build_artifacts_user", region: "eu-west-2") {
+        def artifacts = sh(returnStdout: true, script: "ls -1 artifacts").trim().split("\\r?\\n")
         for (artifact in artifacts) {
             s3Upload(
                 bucket: "${params.ARTIFACTS_BUCKET}",
                 file: artifact,
                 workingDir: "${env.WORKSPACE}/artifacts",
-                acl: 'PublicRead')
+                acl: "PublicRead")
         }
     }
 }
@@ -104,7 +104,7 @@ def retrieveBuildArtifacts() {
 }
 
 def isNightlyBuild() {
-    causes = currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause')
+    causes = currentBuild.getBuildCauses("hudson.triggers.TimerTrigger$TimerTriggerCause")
     return causes ? true : false
 }
 
@@ -146,14 +146,14 @@ def uploadDeployArtifacts(type) {
             bucket: "${params.DEPLOY_BUCKET}",
             path: "safe_authenticator_cli-nightly-x86_64-apple-darwin.tar")
     }
-    withAWS(credentials: 'aws_jenkins_deploy_artifacts_user', region: 'eu-west-2') {
-        def artifacts = sh(returnStdout: true, script: 'ls -1 deploy').trim().split("\\r?\\n")
+    withAWS(credentials: "aws_jenkins_deploy_artifacts_user", region: "eu-west-2") {
+        def artifacts = sh(returnStdout: true, script: "ls -1 deploy").trim().split("\\r?\\n")
         for (artifact in artifacts) {
             s3Upload(
                 bucket: "${params.DEPLOY_BUCKET}",
                 file: artifact,
                 workingDir: "${env.WORKSPACE}/deploy",
-                acl: 'PublicRead')
+                acl: "PublicRead")
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,17 @@ package-version-artifacts-for-deploy:
 	mv safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.tar deploy
 	mv safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.tar deploy
 
+package-nightly-artifacts-for-deploy:
+	rm -f *.tar
+	rm -rf deploy
+	mkdir deploy
+	tar -C artifacts/linux/release -cvf safe_authenticator_cli-nightly-x86_64-unknown-linux-gnu.tar safe_auth
+	tar -C artifacts/win/release -cvf safe_authenticator_cli-nightly-x86_64-pc-windows-gnu.tar safe_auth.exe
+	tar -C artifacts/macos/release -cvf safe_authenticator_cli-nightly-x86_64-apple-darwin.tar safe_auth
+	mv safe_authenticator_cli-nightly-x86_64-unknown-linux-gnu.tar deploy
+	mv safe_authenticator_cli-nightly-x86_64-pc-windows-gnu.tar deploy
+	mv safe_authenticator_cli-nightly-x86_64-apple-darwin.tar deploy
+
 deploy-github-release:
 ifndef GITHUB_TOKEN
 	@echo "Please set GITHUB_TOKEN to the API token for a user who can create releases."


### PR DESCRIPTION
Hi Gabriel,

This will do a nightly build and upload the artifacts to S3. I've tested it by triggering it hourly.

[Here](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_authenticator_cli/detail/PR-56/16/pipeline) is a log that shows the artifacts being uploaded as a result of the timed trigger.

The artifacts are uploaded successfully:
```
aws s3 ls s3://safe-authenticator-cli | sort                                                                                    5.3s  Wed 14 Aug 2019 17:20:06 BST
<other output snipped>
2019-08-14 17:01:05   10956800 safe_authenticator_cli-nightly-x86_64-apple-darwin.tar
2019-08-14 17:01:06   14141440 safe_authenticator_cli-nightly-x86_64-unknown-linux-gnu.tar
2019-08-14 17:01:06   36597760 safe_authenticator_cli-nightly-x86_64-pc-windows-gnu.tar
```

Cheers,

Chris