### PR TITLE
chore(ci): param for deploying nightly

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -32,5 +32,5 @@ USER maidsafe:maidsafe
 ENV CARGO_TARGET_DIR=/target YARN_GPG=no RUST_BACKTRACE=1
 
 RUN rustup component add rustfmt clippy && \
-    cargo test --release --features mock-network
+    cargo test --release --features mock-network --lib --test cli_integration -- --test-threads=1
 ENTRYPOINT ["fixuid"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,8 @@ properties([
     parameters([
         string(name: "ARTIFACTS_BUCKET", defaultValue: "safe-jenkins-build-artifacts"),
         string(name: "CACHE_BRANCH", defaultValue: "master"),
-        string(name: "DEPLOY_BUCKET", defaultValue: "safe-authenticator-cli")
+        string(name: "DEPLOY_BUCKET", defaultValue: "safe-authenticator-cli"),
+        string(name: "DEPLOY_NIGHTLY", defaultValue: "false")
     ]),
     pipelineTriggers([cron(env.BRANCH_NAME == "master" ? "@midnight" : "")])
 ])
@@ -107,7 +108,8 @@ def retrieveBuildArtifacts() {
 
 @NonCPS
 def isNightlyBuild() {
-    return null != currentBuild.getRawBuild().getCause(TimerTriggerCause.class)
+    return "${params.DEPLOY_NIGHTLY}" == "true" ||
+        null != currentBuild.getRawBuild().getCause(TimerTriggerCause.class)
 }
 
 def isVersionChangeCommit() {


### PR DESCRIPTION
Allows 'self service' with the nightly, by specifying a parameter that
the user can control for a master build.

The Dockerfile is slightly modified in line with the other test methods,
as this is the only working configuration at the moment.