### PR TITLE
Release Process Issues and Community Feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -150,7 +150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -483,7 +483,7 @@ name = "bstr"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -538,7 +538,7 @@ name = "c2-chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -726,7 +726,7 @@ dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -745,7 +745,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -990,7 +990,7 @@ name = "escargot"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1667,7 +1667,7 @@ name = "native-tls"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1770,7 +1770,7 @@ dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.49 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1889,7 +1889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1963,7 +1963,7 @@ dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2057,7 +2057,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2398,7 +2398,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2612,7 +2612,7 @@ name = "schannel"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2997,7 +2997,7 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3133,7 +3133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3268,7 +3268,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3291,7 +3291,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (git+https://github.com/rust-lang-nursery/lazy-static.rs.git?tag=1.3.0)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-clean:
 	mkdir artifacts
 ifeq ($(UNAME_S),Linux)
 	docker run --name "safe-authenticator-cli-build-${UUID}" \
-		-v "${PWD}":/usr/src/safe-cli:Z \
+		-v "${PWD}":/usr/src/safe-authenticator-cli:Z \
 		-u ${USER_ID}:${GROUP_ID} \
 		maidsafe/safe-authenticator-cli-build:build \
 		bash -c "rm -rf /target/release && cargo build --release"

--- a/Makefile
+++ b/Makefile
@@ -6,24 +6,8 @@ UNAME_S := $(shell uname -s)
 PWD := $(shell echo $$PWD)
 UUID := $(shell uuidgen | sed 's/-//g')
 S3_BUCKET := safe-jenkins-build-artifacts
-S3_LINUX_DEPLOY_URL := https://safe-authenticator-cli.s3.amazonaws.com/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu-dev.tar
-S3_WIN_DEPLOY_URL := https://safe-authenticator-cli.s3.amazonaws.com/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu-dev.tar
-S3_MACOS_DEPLOY_URL := https://safe-authenticator-cli.s3.amazonaws.com/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin-dev.tar
 GITHUB_REPO_OWNER := maidsafe
 GITHUB_REPO_NAME := safe-authenticator-cli
-define GITHUB_RELEASE_DESCRIPTION
-Command line interface for authenticating with the SAFE Network.
-
-With the SAFE authenticator, users can create SAFE Network accounts, log in using existing credentials (secret and password), authorise applications which need to store data on the network on behalf of the user, and manage permissions granted to applications.
-
-There are also development versions of this release:
-[Linux](${S3_LINUX_DEPLOY_URL})
-[macOS](${S3_MACOS_DEPLOY_URL})
-[Windows](${S3_WIN_DEPLOY_URL})
-
-The development version uses a mocked SAFE network, which allows you to work against a file that mimics the network, where SafeCoins are created for local use.
-endef
-export GITHUB_RELEASE_DESCRIPTION
 
 build-container:
 	rm -rf target/
@@ -274,7 +258,7 @@ endif
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_AUTH_CLI_VERSION} \
 		--name "safe-authenticator-cli" \
-		--description "$$GITHUB_RELEASE_DESCRIPTION";
+		--description "$$(./resources/get_release_description.sh ${SAFE_AUTH_CLI_VERSION})";
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ else ifeq ($(UNAME_S),Darwin)
 	find artifacts -name "safe_auth" -exec strip -x '{}' \;
 else
 	find artifacts -name "safe_auth" -exec strip '{}' \;
+endif
 
 test:
 	rm -rf artifacts
@@ -217,22 +218,33 @@ package-commit_hash-artifacts-for-deploy:
 	mv safe_authenticator_cli-$$(git rev-parse --short HEAD)-x86_64-apple-darwin-dev.tar deploy/dev
 
 package-version-artifacts-for-deploy:
-	rm -f *.tar
 	rm -rf deploy
 	mkdir -p deploy/dev
 	mkdir -p deploy/release
-	tar -C artifacts/linux/release -cvf safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu.tar safe_auth
-	tar -C artifacts/win/release -cvf safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.tar safe_auth.exe
-	tar -C artifacts/macos/release -cvf safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.tar safe_auth
-	tar -C artifacts/linux/dev -cvf safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu-dev.tar safe_auth
-	tar -C artifacts/win/dev -cvf safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu-dev.tar safe_auth.exe
-	tar -C artifacts/macos/dev -cvf safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin-dev.tar safe_auth
-	mv safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu.tar deploy/release
-	mv safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.tar deploy/release
-	mv safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.tar deploy/release
-	mv safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu-dev.tar deploy/dev
-	mv safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu-dev.tar deploy/dev
-	mv safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin-dev.tar deploy/dev
+	( \
+		cd deploy/release; \
+		zip -j safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu.zip \
+			../../artifacts/linux/release/safe_auth; \
+		zip -j safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.zip \
+			../../artifacts/win/release/safe_auth.exe; \
+		zip -j safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.zip \
+			../../artifacts/macos/release/safe_auth; \
+		tar -C ../../artifacts/linux/release \
+			-zcvf safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz safe_auth; \
+		tar -C ../../artifacts/win/release \
+			-zcvf safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.tar.gz safe_auth.exe; \
+		tar -C ../../artifacts/macos/release \
+			-zcvf safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.tar.gz safe_auth; \
+	)
+	( \
+		cd deploy/dev; \
+		tar -C ../../artifacts/linux/dev -cvf \
+			safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu-dev.tar safe_auth; \
+		tar -C ../../artifacts/win/dev -cvf \
+			safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu-dev.tar safe_auth.exe; \
+		tar -C ../../artifacts/macos/dev -cvf \
+			safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin-dev.tar safe_auth; \
+	)
 
 package-nightly-artifacts-for-deploy:
 	rm -f *.tar
@@ -267,17 +279,35 @@ endif
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_AUTH_CLI_VERSION} \
-		--name "safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu.tar" \
-		--file deploy/release/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu.tar;
+		--name "safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu.zip" \
+		--file deploy/release/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu.zip;
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_AUTH_CLI_VERSION} \
-		--name "safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.tar" \
-		--file deploy/release/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.tar;
+		--name "safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.zip" \
+		--file deploy/release/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.zip;
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_AUTH_CLI_VERSION} \
-		--name "safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.tar" \
-		--file deploy/release/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.tar;
+		--name "safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.zip" \
+		--file deploy/release/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.zip;
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_AUTH_CLI_VERSION} \
+		--name "safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+		--file deploy/release/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz;
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_AUTH_CLI_VERSION} \
+		--name "safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.tar.gz" \
+		--file deploy/release/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-pc-windows-gnu.tar.gz;
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_AUTH_CLI_VERSION} \
+		--name "safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.tar.gz" \
+		--file deploy/release/safe_authenticator_cli-${SAFE_AUTH_CLI_VERSION}-x86_64-apple-darwin.tar.gz;

--- a/resources/get_release_description.sh
+++ b/resources/get_release_description.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+version=$1
+if [[ -z "$version" ]]; then
+    echo "You must supply a version number."
+    exit 1
+fi
+
+# The single quotes around EOF is to stop attempted variable and backtick expansion.
+read -r -d '' release_description << 'EOF'
+Command line interface for authenticating with the SAFE Network.
+
+With the SAFE authenticator, users can create SAFE Network accounts, log in using existing credentials (secret and password), authorise applications which need to store data on the network on behalf of the user, and manage permissions granted to applications.
+
+## Development Builds
+
+There are also development versions of this release:
+[Linux](S3_LINUX_DEPLOY_URL)
+[macOS](S3_MACOS_DEPLOY_URL)
+[Windows](S3_WIN_DEPLOY_URL)
+
+The development version uses a mocked SAFE network, allowing you to work against a file that mimics the network, where SafeCoins are created for local use.
+
+## SHA-256 Checksums for Release Versions
+```
+Linux
+zip: ZIP_LINUX_CHECKSUM
+tar.gz: TAR_LINUX_CHECKSUM
+
+macOS
+zip: ZIP_MACOS_CHECKSUM
+tar.gz: TAR_MACOS_CHECKSUM
+
+Windows
+zip: ZIP_WIN_CHECKSUM
+tar.gz: TAR_WIN_CHECKSUM
+```
+
+## Related Links
+* [SAFE CLI](https://github.com/maidsafe/safe-cli/releases/latest/)
+* [SAFE Browser PoC](https://github.com/maidsafe/safe_browser/releases/)
+* [SAFE Vault](https://github.com/maidsafe/safe_vault/releases/latest/)
+EOF
+
+safe_completion_url="https:\/\/github.com\/maidsafe\/safe-cli\/releases\/download\/$version\/safe_completion.sh"
+s3_linux_deploy_url="https:\/\/safe-authenticator-cli.s3.amazonaws.com\/safe_authenticator_cli-$version-x86_64-unknown-linux-gnu-dev.zip"
+s3_win_deploy_url="https:\/\/safe-authenticator-cli.s3.amazonaws.com\/safe_authenticator_cli-$version-x86_64-pc-windows-gnu-dev.zip"
+s3_macos_deploy_url="https:\/\/safe-authenticator-cli.s3.amazonaws.com\/safe_authenticator_cli-$version-x86_64-apple-darwin-dev.zip"
+zip_linux_checksum=$(sha256sum \
+    "./deploy/release/safe_authenticator_cli-$version-x86_64-unknown-linux-gnu.zip" | \
+    awk '{ print $1 }')
+zip_macos_checksum=$(sha256sum \
+    "./deploy/release/safe_authenticator_cli-$version-x86_64-apple-darwin.zip" | \
+    awk '{ print $1 }')
+zip_win_checksum=$(sha256sum \
+    "./deploy/release/safe_authenticator_cli-$version-x86_64-pc-windows-gnu.zip" | \
+    awk '{ print $1 }')
+tar_linux_checksum=$(sha256sum \
+    "./deploy/release/safe_authenticator_cli-$version-x86_64-unknown-linux-gnu.tar.gz" | \
+    awk '{ print $1 }')
+tar_macos_checksum=$(sha256sum \
+    "./deploy/release/safe_authenticator_cli-$version-x86_64-apple-darwin.tar.gz" | \
+    awk '{ print $1 }')
+tar_win_checksum=$(sha256sum \
+    "./deploy/release/safe_authenticator_cli-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    awk '{ print $1 }')
+
+release_description=$(sed "s/S3_LINUX_DEPLOY_URL/$s3_linux_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_MACOS_DEPLOY_URL/$s3_macos_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_WIN_DEPLOY_URL/$s3_win_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/SAFE_COMPLETION_URL/$safe_completion_url/g" <<< "$release_description")
+release_description=$(sed "s/ZIP_LINUX_CHECKSUM/$zip_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/ZIP_MACOS_CHECKSUM/$zip_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/ZIP_WIN_CHECKSUM/$zip_win_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_LINUX_CHECKSUM/$tar_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_MACOS_CHECKSUM/$tar_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_WIN_CHECKSUM/$tar_win_checksum/g" <<< "$release_description")
+echo "$release_description"


### PR DESCRIPTION
Hi Gabriel,

This one changes the release process a bit:

* Fix the problem with the version number
* Do a full clean build as opposed to building with a cache when we're using `master`
* Automatically add SHA-256 checksums for the release assets
* Distribute assets as zips and tar.gz

There is an [example](https://github.com/jacderida/safe-authenticator-cli/releases/tag/0.2.1) release on my fork.

I've verified that the Linux asset now has the correct version number:
```
vagrant@ubuntu-bionic:~$ curl -L -O https://github.com/jacderida/safe-authenticator-cli/releases/download/0.2.1/safe_authenticator_cli-0.2.1-x86_64-unknown-linux-gnu.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   651    0   651    0     0   1745      0 --:--:-- --:--:-- --:--:--  1745
100 5140k  100 5140k    0     0  1981k      0  0:00:02  0:00:02 --:--:-- 2596k
vagrant@ubuntu-bionic:~$ tar xvf safe_authenticator_cli-0.2.1-x86_64-unknown-linux-gnu.tar.gz safe_auth
vagrant@ubuntu-bionic:~$ ./safe_auth --version
safe_auth 0.2.1
```

Cheers,

Chris